### PR TITLE
Potential fix for code scanning alert no. 7: Resolving XML external entity in user-controlled data

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
@@ -888,7 +888,11 @@ public class JobSpec {
 
     public void parse(File file) {
         try {
-            doc = new SAXBuilder(true).build(file);
+            SAXBuilder builder = new SAXBuilder();
+            builder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            builder.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            doc = builder.build(file);
 
         } catch (Exception e) {
             throw new SpecBuilderException("Failed to parse job spec XML, " + e);
@@ -920,7 +924,10 @@ public class JobSpec {
 
     public void parse(String cjsl) {
         try {
-            SAXBuilder builder = new SAXBuilder(true);
+            SAXBuilder builder = new SAXBuilder();
+            builder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            builder.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             builder.setEntityResolver(new DTDRedirector());
             doc = builder.build(new StringReader(cjsl));
 


### PR DESCRIPTION
Potential fix for [https://github.com/bombastictranz/OpenCue/security/code-scanning/7](https://github.com/bombastictranz/OpenCue/security/code-scanning/7)

To fix the problem, we need to disable the parsing of external entities in the `SAXBuilder` instance. This can be achieved by setting specific features on the underlying XML parser to disallow DTD declarations and external entities. This ensures that the XML parser does not process any external entities, mitigating the risk of XXE attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
