### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text storage of sensitive information

### DIFF
--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -1077,12 +1077,11 @@ class FrameAttendantThread(threading.Thread):
         tempPassword = str(uuid.uuid4())
         # Command wrapper
         command = r"""#!/bin/sh
-useradd -u %s -g %s -p %s %s >& /dev/null || true;
+useradd -u %s -g %s -p $TEMP_PASSWORD %s >& /dev/null || true;
 exec su -s %s %s -c "echo \$$; %s /usr/bin/time -p -o %s %s %s"
 """ % (
             uid,
             gid,
-            tempPassword,
             runFrame.user_name,
             self.docker_agent.docker_shell_path,
             runFrame.user_name,
@@ -1121,6 +1120,8 @@ exec su -s %s %s -c "echo \$$; %s /usr/bin/time -p -o %s %s %s"
         docker_client = None
         container_id = "00000000"
         frameInfo.pid = -1
+        env = os.environ.copy()
+        env['TEMP_PASSWORD'] = tempPassword
         try:
             log_stream = None
             docker_client, container = self.docker_agent.runContainer(


### PR DESCRIPTION
Potential fix for [https://github.com/bombastictranz/OpenCue/security/code-scanning/6](https://github.com/bombastictranz/OpenCue/security/code-scanning/6)

To fix the problem, we should avoid storing the temporary password in clear text. Instead, we can use a secure method to handle the password. One approach is to use environment variables to pass the password securely to the subprocess. This way, the password is not written to a file and is less likely to be exposed.

We will:
1. Remove the password from the `command` string.
2. Set the password as an environment variable before executing the command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
